### PR TITLE
add test cases with inner IPv6 packet for GTP6 non-drop-in and GTP6 d…

### DIFF
--- a/extras/ietf105/runner.py
+++ b/extras/ietf105/runner.py
@@ -628,6 +628,73 @@ class Program(object):
         for p in c4.pg_read_packets():
             p.show2()
 
+    def test_gtp6_drop_in_ipv6(self):
+        # TESTS:
+        # trace add af-packet-input 10
+        # pg interface on c1 172.20.0.1
+        # pg interface on c4 B::1/120
+
+        self.start_containers()
+
+        print("Deleting the old containers...")
+        time.sleep(30)
+        print("Starting the new containers...")
+
+        c1 = self.containers.get(self.get_name(self.instance_names[0]))
+        c2 = self.containers.get(self.get_name(self.instance_names[1]))
+        c3 = self.containers.get(self.get_name(self.instance_names[2]))
+        c4 = self.containers.get(self.get_name(self.instance_names[-1]))
+
+        c1.pg_create_interface(local_ip="C::1/120", remote_ip="C::2",
+            local_mac="aa:bb:cc:dd:ee:01", remote_mac="aa:bb:cc:dd:ee:02")
+        c4.pg_create_interface(local_ip="B::1/120", remote_ip="B::2",
+            local_mac="aa:bb:cc:dd:ee:11", remote_mac="aa:bb:cc:dd:ee:22")
+
+        c1.vppctl_exec("set sr encaps source addr A1::1")
+        c1.vppctl_exec("sr policy add bsid D4:: next D2:: next D3::")
+
+        c1.vppctl_exec("sr localsid prefix D::/64 behavior end.m.gtp6.d.di D4::/64")
+
+        c2.vppctl_exec("sr localsid address D2:: behavior end")
+
+        c3.vppctl_exec("sr localsid address D3:: behavior end")
+
+        c4.vppctl_exec("sr localsid prefix D4::/64 behavior end.m.gtp6.e")
+
+        c2.set_ipv6_route("eth2", "A2::2", "D3::/128")
+        c2.set_ipv6_route("eth1", "A1::1", "C::/120")
+        c3.set_ipv6_route("eth2", "A3::2", "D4::/32")
+        c3.set_ipv6_route("eth1", "A2::1", "C::/120")
+        c4.set_ip_pgroute("pg0", "B::2", "D::2/128")
+
+        print("Waiting...")
+        time.sleep(30)
+
+        p = (Ether(src="aa:bb:cc:dd:ee:02", dst="aa:bb:cc:dd:ee:01")/
+                IPv6(src="C::2", dst="D::2")/
+             UDP(sport=2152, dport=2152)/
+             GTP_U_Header(gtp_type="g_pdu", teid=200)/
+             IPv6(src="2001::1", dst="2002::1")/ICMPv6EchoRequest())
+
+        print("Sending packet on {}:".format(c1.name))
+        p.show2()
+
+        c1.enable_trace(10)
+        c4.enable_trace(10)
+
+        c4.pg_start_capture()
+
+        c1.pg_create_stream(p)
+        c1.pg_enable()
+
+        # timeout (sleep) if needed
+        print("Sleeping")
+        time.sleep(5)
+
+        print("Receiving packet on {}:".format(c4.name))
+        for p in c4.pg_read_packets():
+            p.show2()
+
     def test_gtp6(self):
         # TESTS:
         # trace add af-packet-input 10
@@ -679,6 +746,73 @@ class Program(object):
              GTP_U_Header(gtp_type="g_pdu", teid=200)/
              IP(src="172.100.0.1", dst="172.200.0.1")/
              ICMP())
+
+        print("Sending packet on {}:".format(c1.name))
+        p.show2()
+
+        c1.enable_trace(10)
+        c4.enable_trace(10)
+
+        c4.pg_start_capture()
+
+        c1.pg_create_stream(p)
+        c1.pg_enable()
+
+        # timeout (sleep) if needed
+        print("Sleeping")
+        time.sleep(5)
+
+        print("Receiving packet on {}:".format(c4.name))
+        for p in c4.pg_read_packets():
+            p.show2()
+
+    def test_gtp6_ipv6(self):
+        # TESTS:
+        # trace add af-packet-input 10
+        # pg interface on c1 172.20.0.1
+        # pg interface on c4 B::1/120
+
+        self.start_containers()
+
+        print("Deleting the old containers...")
+        time.sleep(30)
+        print("Starting the new containers...")
+
+        c1 = self.containers.get(self.get_name(self.instance_names[0]))
+        c2 = self.containers.get(self.get_name(self.instance_names[1]))
+        c3 = self.containers.get(self.get_name(self.instance_names[2]))
+        c4 = self.containers.get(self.get_name(self.instance_names[-1]))
+
+        c1.pg_create_interface(local_ip="C::1/120", remote_ip="C::2",
+            local_mac="aa:bb:cc:dd:ee:01", remote_mac="aa:bb:cc:dd:ee:02")
+        c4.pg_create_interface(local_ip="B::1/120", remote_ip="B::2",
+            local_mac="aa:bb:cc:dd:ee:11", remote_mac="aa:bb:cc:dd:ee:22")
+
+        c1.vppctl_exec("set sr encaps source addr A1::1")
+        c1.vppctl_exec("sr policy add bsid D4:: next D2:: next D3::")
+
+        c1.vppctl_exec("sr localsid prefix D::/64 behavior end.m.gtp6.d D4::/64")
+
+        c2.vppctl_exec("sr localsid address D2:: behavior end")
+
+        c3.vppctl_exec("sr localsid address D3:: behavior end")
+
+        c4.vppctl_exec("sr localsid prefix D4::/64 behavior end.dt6 2")
+
+        c2.set_ipv6_route("eth2", "A2::2", "D3::/128")
+        c2.set_ipv6_route("eth1", "A1::1", "C::/120")
+        c3.set_ipv6_route("eth2", "A3::2", "D4::/32")
+        c3.set_ipv6_route("eth1", "A2::1", "C::/120")
+        c4.set_ipv6_pgroute("pg0", "B::2", "2002::1/128")
+
+        print("Waiting...")
+        time.sleep(30)
+
+        p = (Ether(src="aa:bb:cc:dd:ee:02", dst="aa:bb:cc:dd:ee:01")/
+                IPv6(src="C::2", dst="D::2")/
+             UDP(sport=2152, dport=2152)/
+             GTP_U_Header(gtp_type="g_pdu", teid=200)/
+             IPv6(src="2001::1", dst="2002::1")/ICMPv6EchoRequest())
 
         print("Sending packet on {}:".format(c1.name))
         p.show2()
@@ -769,7 +903,7 @@ def get_args():
             help="Test related commands.")
 
     p3.add_argument("op", choices=[
-        "ping", "srv6", "tmap", "gtp6_drop_in", "gtp6"])
+        "ping", "srv6", "tmap", "gtp6_drop_in", "gtp6_drop_in_ipv6", "gtp6", "gtp6_ipv6"])
 
     args = parser.parse_args()
     if not hasattr(args, "op") or not args.op:
@@ -807,8 +941,12 @@ def main(op=None, image=None, prefix=None, verbose=None, index=None, command=Non
             program.test_tmap()
         elif op == 'gtp6_drop_in':
             program.test_gtp6_drop_in()
+        elif op == 'gtp6_drop_in_ipv6':
+            program.test_gtp6_drop_in_ipv6()
         elif op == 'gtp6':
             program.test_gtp6()
+        elif op == 'gtp6_ipv6':
+            program.test_gtp6_ipv6()
 
     except Exception:
         program.logger.exception("")


### PR DESCRIPTION
Add the following test cases.

1. gtp6_drop_in_ipv6
Using the IPv6 packet as the inner packet for GTP6 drop-in case.

2. gtp6_ipv6
Using the IPv6 packet as the inner packet for GTP6 non-drop-in case.