### PR TITLE
This commit fix #20, fix #25 and fix #26

### DIFF
--- a/extras/ietf105/Dockerfile.j2.release
+++ b/extras/ietf105/Dockerfile.j2.release
@@ -17,14 +17,11 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*; \
     mv /usr/sbin/tcpdump /usr/bin/tcpdump
 
-RUN set -eux; \
-    mkdir -p {{vpp_path}}
-
-COPY . / {{vpp_path}}/
-
-WORKDIR {{vpp_path}}
+WORKDIR /tmp
 
 RUN set -eux; \
+    git clone -b ietf105-hackathon https://github.com/filvarga/srv6-mobile.git; \
+    cd /tmp/srv6-mobile; \
     make wipe; \
     export UNATTENDED=y; \
     make install-dep; \
@@ -33,11 +30,11 @@ RUN set -eux; \
     make pkg-deb; \
     rm -rf .ccache; \
     find . -type f -name '*.o' -delete ; \
-    cd {{vpp_path}}/build-root; \
+    cd /tmp/srv6-mobile/build-root; \
     rm vpp-api-python_*.deb; \
     dpkg -i *.deb ; \
-    cp {{vpp_path}}/startup.conf /etc/startup.conf; \
-    rm -rf {{vpp_path}}
+    cp /tmp/srv6-mobile/extras/ietf105/startup.conf.j2 /etc/startup.conf; \
+    rm -rf /tmp/srv6-mobile
 
 WORKDIR /
  

--- a/src/plugins/srv6-mobile/gtp4_e.c
+++ b/src/plugins/srv6-mobile/gtp4_e.c
@@ -69,7 +69,7 @@ clb_format_srv6_end_m_gtp4_e (u8 * s, va_list * args)
 
   s = format (s, "SRv6 End gtp4.e\n\t");
 
-  s = format (s, "Local Prefix: %U/%d\n", format_ip6_address, &ls_mem->local_prefix, ls_mem->local_prefixlen);
+  s = format (s, "IPv4 address position: %d\n", ls_mem->local_prefixlen);
 
   return s;
 }
@@ -79,18 +79,16 @@ clb_unformat_srv6_end_m_gtp4_e (unformat_input_t * input, va_list * args)
 {
   void **plugin_mem_p = va_arg (*args, void **);
   srv6_end_gtp4_param_t *ls_mem;
-  ip6_address_t local_prefix;
   u32 local_prefixlen;
 
-  if (!unformat (input, "end.m.gtp4.e %U/%d",
-	  unformat_ip6_address, &local_prefix, &local_prefixlen))
+  if (!unformat (input, "end.m.gtp4.e v4src_position %d",
+	  &local_prefixlen))
     return 0;
 
   ls_mem = clib_mem_alloc_aligned_at_offset (sizeof *ls_mem, 0, 0, 1);
   clib_memset (ls_mem, 0, sizeof *ls_mem);
   *plugin_mem_p = ls_mem;
 
-  ls_mem->local_prefix = local_prefix;
   ls_mem->local_prefixlen = local_prefixlen;
 
   return 1;

--- a/src/plugins/srv6-mobile/mobile.h
+++ b/src/plugins/srv6-mobile/mobile.h
@@ -36,7 +36,6 @@ typedef struct srv6_end_gtp6_param_s
 
 typedef struct srv6_end_gtp4_param_s
 {
-  ip6_address_t local_prefix;
   u32 local_prefixlen;
 } srv6_end_gtp4_param_t;
 

--- a/src/vnet/srv6/sr_policy_rewrite.c
+++ b/src/vnet/srv6/sr_policy_rewrite.c
@@ -890,7 +890,7 @@ sr_policy_command_fn (vlib_main_t * vm, unformat_input_t * input,
 	is_encap = 1;
       else if (unformat (input, "insert"))
 	is_encap = 0;
-      else if (unformat (input, "gtp4_removal sr_prefix %U/%d local_prefix %U/%d",
+      else if (unformat (input, "gtp4_removal sr_prefix %U/%d v6src_prefix %U/%d",
            unformat_ip6_address, &tmap_prefix,  &gtp4_mask_width,
            unformat_ip6_address, &tmap_localsid, &localsid_mask_width))
         {
@@ -1481,7 +1481,9 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
           ip4_gtpu_header_t *hdr0, *hdr1, *hdr2, *hdr3;
           ip4_address_t sr_addr0, sr_addr1, sr_addr2, sr_addr3;
           ip4_address_t dst_addr0, dst_addr1, dst_addr2, dst_addr3;
+#if 0
           u16 sr_port0 = 0, sr_port1 = 0, sr_port2 = 0, sr_port3 = 0;
+#endif
           u32 teid0 = 0, teid1 = 0, teid2 = 0, teid3 = 0;
 	  u8 *teidp0 = NULL, *teidp1 = NULL, *teidp2 = NULL, *teidp3 = NULL;
 	  u32 offset, shift;
@@ -1565,7 +1567,9 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
 	       teidp0 = (u8 *)&teid0;
                sr_addr0 = hdr0->ip4.src_address;
                dst_addr0 = hdr0->ip4.dst_address;
+#if 0
                sr_port0 = hdr0->udp.src_port;
+#endif
                vlib_buffer_advance (b0, (word) sizeof(ip4_gtpu_header_t));
 	       encap0 = vlib_buffer_get_current (b0);
                clib_memcpy_fast (vlib_buffer_get_current (b0) - vec_len (sl0->rewrite),
@@ -1585,7 +1589,9 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
 	       teidp1 = (u8 *)&teid1;
                sr_addr1 = hdr1->ip4.src_address;
                dst_addr1 = hdr1->ip4.dst_address;
+#if 0
                sr_port1 = hdr1->udp.src_port;
+#endif
                vlib_buffer_advance (b1, (word) sizeof(ip4_gtpu_header_t));
 	       encap1 = vlib_buffer_get_current (b1);
                clib_memcpy_fast (vlib_buffer_get_current (b1) - vec_len (sl1->rewrite),
@@ -1604,7 +1610,9 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
 	       teidp2 =  (u8 *)&teid2;
                sr_addr2 = hdr2->ip4.src_address;
                dst_addr2 = hdr2->ip4.dst_address;
+#if 0
                sr_port2 = hdr2->udp.src_port;
+#endif
                vlib_buffer_advance (b2, (word) sizeof(ip4_gtpu_header_t));
 	       encap2 = vlib_buffer_get_current (b2);
                clib_memcpy_fast (vlib_buffer_get_current (b2) - vec_len (sl2->rewrite),
@@ -1623,7 +1631,9 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
 	       teidp3 = (u8 *)&teid3;
                sr_addr3 = hdr3->ip4.src_address;
                dst_addr3 = hdr3->ip4.dst_address;
+#if 0
                sr_port3 = hdr3->udp.src_port;
+#endif
                vlib_buffer_advance (b3, (word) sizeof(ip4_gtpu_header_t));
 	       encap3 = vlib_buffer_get_current (b3);
                clib_memcpy_fast (vlib_buffer_get_current (b3) - vec_len (sl3->rewrite),
@@ -1698,19 +1708,25 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      clib_memcpy_fast(&ip0->src_address.as_u8[0], &sl0->local_prefix.as_u8[0], 16);
 	      if (PREDICT_TRUE(shift == 0)) {
 		clib_memcpy_fast(&ip0->src_address.as_u8[offset], &sr_addr0.as_u32, 4);
+#if 0
 		clib_memcpy_fast(&ip0->src_address.as_u8[offset+4], &sr_port0, 2);
+#endif
 	      } else {
+#if 0
 		u8 *pp = (u8 *)&sr_port0;
+#endif
 
 		for (index = 0; index < 4; index++) {
 		  ip0->src_address.as_u8[offset] |= sr_addr0.as_u8[index] >> shift;
 		  ip0->src_address.as_u8[offset + 1] |= sr_addr0.as_u8[index] << (8 - shift);
 		}
 
+#if 0
 		for (index = 0; index < 2; index++) {
 		  ip0->src_address.as_u8[offset + 4] |= (pp[index] >> shift);
 		  ip0->src_address.as_u8[offset + 5] |= (pp[index] << (8 - shift));
 		}
+#endif
 	      }
             }
 
@@ -1747,19 +1763,25 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      clib_memcpy_fast(&ip1->src_address.as_u8[0], &sl1->local_prefix.as_u8[0], 16);
 	      if (PREDICT_TRUE(shift == 0)) {
 		clib_memcpy_fast(&ip1->src_address.as_u8[offset], &sr_addr1.as_u32, 4);
+#if 0
 		clib_memcpy_fast(&ip1->src_address.as_u8[offset+4], &sr_port1, 2);
+#endif
 	      } else {
+#if 0
 		u8 *pp = (u8 *)&sr_port1;
+#endif
 
 		for (index = 0; index < 4; index++) {
 		  ip1->src_address.as_u8[offset] |= sr_addr1.as_u8[index] >> shift;
 		  ip1->src_address.as_u8[offset + 1] |= sr_addr1.as_u8[index] << (8 - shift);
 		}
 
+#if 0
 		for (index = 0; index < 2; index++) {
 		  ip1->src_address.as_u8[offset + 4] |= (pp[index] >> shift);
 		  ip1->src_address.as_u8[offset + 5] |= (pp[index] << (8 - shift));
 		}
+#endif
 	      }
             }
 
@@ -1796,19 +1818,25 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      clib_memcpy_fast(&ip2->src_address.as_u8[0], &sl2->local_prefix.as_u8[0], 16);
 	      if (PREDICT_TRUE(shift == 0)) {
 		clib_memcpy_fast(&ip2->src_address.as_u8[offset], &sr_addr2.as_u32, 4);
+#if 0
 		clib_memcpy_fast(&ip2->src_address.as_u8[offset+4], &sr_port2, 2);
+#endif
 	      } else {
+#if 0
 		u8 *pp = (u8 *)&sr_port2;
+#endif
 
 		for (index = 0; index < 4; index++) {
 		  ip2->src_address.as_u8[offset] |= sr_addr2.as_u8[index] >> shift;
 		  ip2->src_address.as_u8[offset + 1] |= sr_addr2.as_u8[index] << (8 - shift);
 		}
 
+#if 0
 		for (index = 0; index < 2; index++) {
 		  ip2->src_address.as_u8[offset + 4] |= (pp[index] >> shift);
 		  ip2->src_address.as_u8[offset + 5] |= (pp[index] << (8 - shift));
 		}
+#endif
 	      }
             }
 
@@ -1845,19 +1873,25 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      clib_memcpy_fast(&ip3->src_address.as_u8[0], &sl3->local_prefix.as_u8[0], 16);
 	      if (PREDICT_TRUE(shift == 0)) {
 		clib_memcpy_fast(&ip3->src_address.as_u8[offset], &sr_addr3.as_u32, 4);
+#if 0
 		clib_memcpy_fast(&ip3->src_address.as_u8[offset+4], &sr_port3, 2);
+#endif
 	      } else {
+#if 0
 		u8 *pp = (u8 *)&sr_port3;
+#endif
 
 		for (index = 0; index < 4; index++) {
 		  ip3->src_address.as_u8[offset] |= sr_addr3.as_u8[index] >> shift;
 		  ip3->src_address.as_u8[offset + 1] |= sr_addr3.as_u8[index] << (8 - shift);
 		}
 
+#if 0
 		for (index = 0; index < 2; index++) {
 		  ip3->src_address.as_u8[offset + 4] |= (pp[index] >> shift);
 		  ip3->src_address.as_u8[offset + 5] |= (pp[index] << (8 - shift));
 		}
+#endif
 	      }
             }
 
@@ -1963,7 +1997,9 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
           ip4_gtpu_header_t *hdr0;
           ip4_address_t sr_addr0;
           ip4_address_t dst_addr0;
+#if 0
           u16 sr_port0 = 0;
+#endif
           u32 teid0 = 0;
 	  u8 *teidp0 = NULL;
 	  u32 offset, shift;
@@ -1998,7 +2034,9 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      teidp0 = (u8 *)&teid0;
               sr_addr0 = hdr0->ip4.src_address;
               dst_addr0 = hdr0->ip4.dst_address;
+#if 0
               sr_port0 = hdr0->udp.src_port;
+#endif
 
               // go after GTPU, we are at segment header
               vlib_buffer_advance (b0, (word) sizeof(ip4_gtpu_header_t));
@@ -2057,19 +2095,25 @@ sr_policy_rewrite_encaps_v4 (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      clib_memcpy_fast(&ip0->src_address.as_u8[0], &sl0->local_prefix.as_u8[0], 16);
 	      if (PREDICT_TRUE(shift == 0)) {
 		clib_memcpy_fast(&ip0->src_address.as_u8[offset], &sr_addr0.as_u32, 4);
+#if 0
 		clib_memcpy_fast(&ip0->src_address.as_u8[offset+4], &sr_port0, 2);
+#endif
 	      } else {
+#if 0
 		u8 *pp = (u8 *)&sr_port0;
+#endif
 
 		for (index = 0; index < 4; index++) {
 		  ip0->src_address.as_u8[offset] |= sr_addr0.as_u8[index] >> shift;
 		  ip0->src_address.as_u8[offset + 1] |= sr_addr0.as_u8[index] << (8 - shift);
 		}
 
+#if 0
 		for (index = 0; index < 2; index++) {
 		  ip0->src_address.as_u8[offset + 4] |= (pp[index] >> shift);
 		  ip0->src_address.as_u8[offset + 5] |= (pp[index] << (8 - shift));
 		}
+#endif
 	      }
             }
 	  


### PR DESCRIPTION
This commit includes the following change.
1. Support UDP source port based on hash.
2. Change the config term for GTP4.D/E.
3. Reduce the docker image size.

In terms of the above 3, when creating the development image based on the local source code tree, "runner.py infra build" should be used. If creating the release image based on the github source code, "runner.py infra release" should be used.