### PR TITLE
This commit fix #20

### DIFF
--- a/extras/ietf105/Dockerfile.j2
+++ b/extras/ietf105/Dockerfile.j2
@@ -36,8 +36,7 @@ RUN set -eux; \
     cd {{vpp_path}}/build-root; \
     rm vpp-api-python_*.deb; \
     dpkg -i *.deb ; \
-    cp {{vpp_path}}/startup.conf /etc/startup.conf; \
-    rm -rf {{vpp_path}}
+    cp {{vpp_path}}/startup.conf /etc/startup.conf
 
 WORKDIR /
  

--- a/extras/ietf105/Dockerfile.j2.release
+++ b/extras/ietf105/Dockerfile.j2.release
@@ -6,8 +6,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
     inetutils-traceroute \
     ca-certificates \
-    build-essential \
-    git gdb sudo \
+    libmbedcrypto1 \
+    libmbedtls10 \
+    libmbedx509-0 \
+    libnuma1 \
+    sudo \
     iputils-ping \
     net-tools \
     iproute2 \
@@ -19,22 +22,13 @@ RUN set -eux; \
 
 WORKDIR /tmp
 
+COPY startup.conf /etc/startup.conf
+
+COPY deb/ /tmp
+
 RUN set -eux; \
-    git clone -b ietf105-hackathon https://github.com/filvarga/srv6-mobile.git; \
-    cd /tmp/srv6-mobile; \
-    make wipe; \
-    export UNATTENDED=y; \
-    make install-dep; \
-    rm -rf /var/lib/apt/lists/* ; \
-    make build; \
-    make pkg-deb; \
-    rm -rf .ccache; \
-    find . -type f -name '*.o' -delete ; \
-    cd /tmp/srv6-mobile/build-root; \
-    rm vpp-api-python_*.deb; \
     dpkg -i *.deb ; \
-    cp /tmp/srv6-mobile/extras/ietf105/startup.conf.j2 /etc/startup.conf; \
-    rm -rf /tmp/srv6-mobile
+    rm -rf *.deb
 
 WORKDIR /
  


### PR DESCRIPTION
To create the release image (smaller image size), the following step is needed.

1. Run "runner.py infra build" in order to build the normal image.
2. Run "runner.py infra release" in order to build the release image.

When executing the above step 2, the required runtime binaries are extracted from the normal image created at the above step 1. And the release image is created. The size of the release image should be 335M.