### PR TITLE
Fix #21

### DIFF
--- a/extras/ietf105/runner.py
+++ b/extras/ietf105/runner.py
@@ -638,6 +638,128 @@ class Program(object):
         for p in c4.pg_read_packets():
             p.show2()
 
+    def test_gtp4(self):
+        # TESTS:
+        # trace add af-packet-input 10
+        # pg interface on c1 172.20.0.1
+        # pg interface on c4 B::1/120
+
+        self.start_containers()
+
+        c1 = self.containers.get(self.get_name(self.instance_names[0]))
+        c2 = self.containers.get(self.get_name(self.instance_names[1]))
+        c3 = self.containers.get(self.get_name(self.instance_names[2]))
+        c4 = self.containers.get(self.get_name(self.instance_names[-1]))
+
+        c1.pg_create_interface4(local_ip="172.16.0.1/30", remote_ip="172.16.0.2/30",
+            local_mac="aa:bb:cc:dd:ee:01", remote_mac="aa:bb:cc:dd:ee:02")
+        c4.pg_create_interface4(local_ip="1.0.0.2/30", remote_ip="1.0.0.1",
+            local_mac="aa:bb:cc:dd:ee:11", remote_mac="aa:bb:cc:dd:ee:22")
+
+        c1.vppctl_exec("set sr encaps source addr A1::1")
+        c1.vppctl_exec("sr policy add bsid D4:: next D2:: next D3::")
+        c1.vppctl_exec("sr localsid prefix ::ffff:ac14:0001/128 behavior end.m.gtp4.d D4::/32 v6src_prefix C1::/64")
+
+        c2.vppctl_exec("sr localsid address D2:: behavior end")
+
+        c3.vppctl_exec("sr localsid address D3:: behavior end")
+
+        c4.vppctl_exec("sr localsid prefix D4::/32 behavior end.m.gtp4.e v4src_position 64")
+
+        #c1.set_ipv6_route("eth1", "A1::2", "D2::/128")
+        c2.set_ipv6_route("eth2", "A2::2", "D3::/128")
+        c2.set_ipv6_route("eth1", "A1::1", "C::/120")
+        c3.set_ipv6_route("eth2", "A3::2", "D4::/32")
+        c3.set_ipv6_route("eth1", "A2::1", "C::/120")
+        c4.set_ip_pgroute("pg0", "1.0.0.1", "172.20.0.1/32")
+
+        p = (Ether(src="aa:bb:cc:dd:ee:02", dst="aa:bb:cc:dd:ee:01")/
+             IP(src="172.20.0.2", dst="172.20.0.1")/
+             UDP(sport=2152, dport=2152)/
+             GTP_U_Header(gtp_type="g_pdu", teid=200)/
+             IP(src="172.99.0.1", dst="172.99.0.2")/
+             ICMP())
+
+        print("Sending packet on {}:".format(c1.name))
+        p.show2()
+
+        c1.enable_trace(10)
+        c4.enable_trace(10)
+
+        c4.pg_start_capture()
+
+        c1.pg_create_stream(p)
+        c1.pg_enable()
+
+        # timeout (sleep) if needed
+        print("Sleeping")
+        time.sleep(5)
+
+        print("Receiving packet on {}:".format(c4.name))
+        for p in c4.pg_read_packets():
+            p.show2()
+
+    def test_gtp4_ipv6(self):
+        # TESTS:
+        # trace add af-packet-input 10
+        # pg interface on c1 172.20.0.1
+        # pg interface on c4 B::1/120
+
+        self.start_containers()
+
+
+        c1 = self.containers.get(self.get_name(self.instance_names[0]))
+        c2 = self.containers.get(self.get_name(self.instance_names[1]))
+        c3 = self.containers.get(self.get_name(self.instance_names[2]))
+        c4 = self.containers.get(self.get_name(self.instance_names[-1]))
+
+        c1.pg_create_interface4(local_ip="172.16.0.1/30", remote_ip="172.16.0.2/30",
+            local_mac="aa:bb:cc:dd:ee:01", remote_mac="aa:bb:cc:dd:ee:02")
+        c4.pg_create_interface4(local_ip="1.0.0.2/30", remote_ip="1.0.0.1",
+            local_mac="aa:bb:cc:dd:ee:11", remote_mac="aa:bb:cc:dd:ee:22")
+
+        c1.vppctl_exec("set sr encaps source addr A1::1")
+        c1.vppctl_exec("sr policy add bsid D4:: next D2:: next D3::")
+        c1.vppctl_exec("sr localsid prefix ::ffff:ac14:0001/128 behavior end.m.gtp4.d D4::/32 v6src_prefix C1::/64")
+
+        c2.vppctl_exec("sr localsid address D2:: behavior end")
+
+        c3.vppctl_exec("sr localsid address D3:: behavior end")
+
+        c4.vppctl_exec("sr localsid prefix D4::/32 behavior end.m.gtp4.e v4src_position 64")
+
+        c2.set_ipv6_route("eth2", "A2::2", "D3::/128")
+        c2.set_ipv6_route("eth1", "A1::1", "C::/120")
+        c3.set_ipv6_route("eth2", "A3::2", "D4::/32")
+        c3.set_ipv6_route("eth1", "A2::1", "C::/120")
+        c4.set_ip_pgroute("pg0", "1.0.0.1", "172.20.0.1/32")
+
+        p = (Ether(src="aa:bb:cc:dd:ee:02", dst="aa:bb:cc:dd:ee:01")/
+             IP(src="172.20.0.2", dst="172.20.0.1")/
+             UDP(sport=2152, dport=2152)/
+             GTP_U_Header(gtp_type="g_pdu", teid=200)/
+             IPv6(src="2001::1", dst="2002::1")/
+             ICMPv6EchoRequest())
+
+        print("Sending packet on {}:".format(c1.name))
+        p.show2()
+
+        c1.enable_trace(10)
+        c4.enable_trace(10)
+
+        c4.pg_start_capture()
+
+        c1.pg_create_stream(p)
+        c1.pg_enable()
+
+        # timeout (sleep) if needed
+        print("Sleeping")
+        time.sleep(5)
+
+        print("Receiving packet on {}:".format(c4.name))
+        for p in c4.pg_read_packets():
+            p.show2()
+
     def test_gtp6_drop_in(self):
         # TESTS:
         # trace add af-packet-input 10
@@ -995,7 +1117,7 @@ def get_args():
             help="Test related commands.")
 
     p3.add_argument("op", choices=[
-        "ping", "srv6", "tmap", "tmap_ipv6",  "gtp6_drop_in", "gtp6_drop_in_ipv6", "gtp6", "gtp6_ipv6"])
+        "ping", "srv6", "tmap", "tmap_ipv6", "gtp4", "gtp4_ipv6", "gtp6_drop_in", "gtp6_drop_in_ipv6", "gtp6", "gtp6_ipv6"])
 
     args = parser.parse_args()
     if not hasattr(args, "op") or not args.op:
@@ -1042,6 +1164,10 @@ def main(op=None, prefix=None, verbose=None, image=None, index=None, command=Non
             program.test_tmap()
         elif op == 'tmap_ipv6':
             program.test_tmap_ipv6()
+        elif op == 'gtp4':
+            program.test_gtp4()
+        elif op == 'gtp4_ipv6':
+            program.test_gtp4_ipv6()
         elif op == 'gtp6_drop_in':
             program.test_gtp6_drop_in()
         elif op == 'gtp6_drop_in_ipv6':

--- a/src/plugins/srv6-mobile/CMakeLists.txt
+++ b/src/plugins/srv6-mobile/CMakeLists.txt
@@ -14,6 +14,7 @@
 add_vpp_plugin(srv6mobile
   SOURCES
   gtp4_e.c
+  gtp4_d.c
   gtp6_e.c
   gtp6_d.c
   gtp6_d_di.c

--- a/src/plugins/srv6-mobile/gtp4_d.c
+++ b/src/plugins/srv6-mobile/gtp4_d.c
@@ -1,0 +1,190 @@
+/*
+ * srv6_end_m_gtp4_d.c
+ *
+ * Copyright (c) 2019 Cisco and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <vnet/vnet.h>
+#include <vnet/adj/adj.h>
+#include <vnet/plugin/plugin.h>
+#include <vpp/app/version.h>
+#include <srv6-mobile/mobile.h>
+
+srv6_end_main_v4_decap_t srv6_end_main_v4_decap;
+
+static void
+clb_dpo_lock_srv6_end_m_gtp4_d (dpo_id_t * dpo)
+{
+}
+
+static void
+clb_dpo_unlock_srv6_end_m_gtp4_d (dpo_id_t * dpo)
+{
+}
+
+static u8 *
+clb_dpo_format_srv6_end_m_gtp4_d (u8 * s, va_list * args)
+{
+  index_t index = va_arg (*args, index_t);
+  CLIB_UNUSED (u32 indent) = va_arg (*args, u32);
+
+  return (format (s, "SR: dynamic_proxy_index:[%u]", index));
+}
+
+const static dpo_vft_t dpo_vft = {
+  .dv_lock = clb_dpo_lock_srv6_end_m_gtp4_d,
+  .dv_unlock = clb_dpo_unlock_srv6_end_m_gtp4_d,
+  .dv_format = clb_dpo_format_srv6_end_m_gtp4_d,
+};
+
+const static char *const srv6_end_m_gtp4_d_nodes[] = {
+  "srv6-end-m-gtp4-d",
+  NULL,
+};
+
+const static char *const *const dpo_nodes[DPO_PROTO_NUM] = {
+  [DPO_PROTO_IP4] = srv6_end_m_gtp4_d_nodes,
+};
+
+static u8 fn_name[] = "SRv6-End.M.GTP4.D-plugin";
+static u8 keyword_str[] = "end.m.gtp4.d";
+static u8 def_str[] = "Endpoint function with dencapsulation for IPv6/GTP tunnel";
+static u8 param_str[] = "<sr-prefix>/<sr-prefixlen> v6src_prefix <v6src_prefix>/<prefixlen>";
+
+static u8 *
+clb_format_srv6_end_m_gtp4_d (u8 * s, va_list * args)
+{
+  srv6_end_gtp4_param_t *ls_mem = va_arg (*args, void *);
+
+  s = format (s, "SRv6 End gtp4.d\n\t");
+
+  s = format (s, "SR Prefix: %U/%d, ", format_ip6_address, &ls_mem->sr_prefix, ls_mem->sr_prefixlen);
+
+  s = format (s, "v6src Prefix: %U/%d\n", format_ip6_address, &ls_mem->v6src_prefix, ls_mem->v6src_prefixlen);
+
+  return s;
+}
+
+static uword
+clb_unformat_srv6_end_m_gtp4_d (unformat_input_t * input, va_list * args)
+{
+  void **plugin_mem_p = va_arg (*args, void **);
+  srv6_end_gtp4_param_t *ls_mem;
+  ip6_address_t sr_prefix;
+  u32 sr_prefixlen;
+  ip6_address_t v6src_prefix;
+  u32 v6src_prefixlen;
+
+  if (!unformat (input, "end.m.gtp4.d %U/%d v6src_prefix %U/%d",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen,
+	 unformat_ip6_address, &v6src_prefix, &v6src_prefixlen))
+    {
+      return 0;
+    }
+
+  ls_mem = clib_mem_alloc_aligned_at_offset (sizeof *ls_mem, 0, 0, 1);
+  clib_memset (ls_mem, 0, sizeof *ls_mem);
+  *plugin_mem_p = ls_mem;
+
+  ls_mem->sr_prefix = sr_prefix;
+  ls_mem->sr_prefixlen = sr_prefixlen;
+
+  ls_mem->v6src_prefix = v6src_prefix;
+  ls_mem->v6src_prefixlen = v6src_prefixlen;
+
+  return 1;
+}
+
+static int
+clb_creation_srv6_end_m_gtp4_d (ip6_sr_localsid_t * localsid)
+{
+  return 0;
+}
+
+static int
+clb_removal_srv6_end_m_gtp4_d (ip6_sr_localsid_t * localsid)
+{
+  srv6_end_gtp4_param_t *ls_mem;
+
+  ls_mem = localsid->plugin_mem;
+
+  clib_mem_free (ls_mem);
+
+  return 0;
+}
+
+static clib_error_t *
+srv6_end_m_gtp4_d_init (vlib_main_t * vm)
+{
+  srv6_end_main_v4_decap_t *sm = &srv6_end_main_v4_decap;
+  ip6_header_t *ip6;
+  dpo_type_t dpo_type;
+  vlib_node_t *node;
+  u32 rc;
+
+  sm->vlib_main = vm;
+  sm->vnet_main = vnet_get_main ();
+
+  node = vlib_get_node_by_name (vm, (u8 *) "srv6-end-m-gtp4-d");
+  sm->end_m_gtp4_d_node_index = node->index;
+
+  node = vlib_get_node_by_name (vm, (u8 *) "error-drop");
+  sm->error_node_index = node->index;
+
+  ip6 = &sm->cache_hdr;
+
+  clib_memset_u8 (ip6, 0, sizeof(ip6_header_t));
+
+  // IPv6 header (default)
+  ip6->ip_version_traffic_class_and_flow_label = 0x60;
+  ip6->hop_limit = 64;
+  ip6->protocol = IP_PROTOCOL_IPV6;
+
+  dpo_type = dpo_register_new_type (&dpo_vft, dpo_nodes);
+
+  rc = sr_localsid_register_function (vm,
+                                      fn_name,
+                                      keyword_str,
+                                      def_str,
+                                      param_str,
+                                      128, //prefix len
+                                      &dpo_type,
+                                      clb_format_srv6_end_m_gtp4_d,
+                                      clb_unformat_srv6_end_m_gtp4_d,
+                                      clb_creation_srv6_end_m_gtp4_d,
+                                      clb_removal_srv6_end_m_gtp4_d);
+  if (rc < 0)
+    clib_error_return (0, "SRv6 Endpoint GTP4.D LocalSID function"
+                          "couldn't be registered");
+  return 0;
+}
+
+/* *INDENT-OFF* */
+VNET_FEATURE_INIT (srv6_end_m_gtp4_d, static) =
+{
+  .arc_name = "ip4-unicast",
+  .node_name = "srv6-end-m-gtp4-d",
+  .runs_before = 0,
+};
+
+VLIB_INIT_FUNCTION (srv6_end_m_gtp4_d_init);
+/* *INDENT-ON* */
+
+/*
+ * fd.io coding-style-patch-verification: ON
+ *
+ * Local Variables:
+ * eval: (c-set-style "gnu")
+ * End:
+ */

--- a/src/plugins/srv6-mobile/gtp4_e.c
+++ b/src/plugins/srv6-mobile/gtp4_e.c
@@ -69,7 +69,7 @@ clb_format_srv6_end_m_gtp4_e (u8 * s, va_list * args)
 
   s = format (s, "SRv6 End gtp4.e\n\t");
 
-  s = format (s, "IPv4 address position: %d\n", ls_mem->local_prefixlen);
+  s = format (s, "IPv4 address position: %d\n", ls_mem->v4src_position);
 
   return s;
 }
@@ -79,17 +79,17 @@ clb_unformat_srv6_end_m_gtp4_e (unformat_input_t * input, va_list * args)
 {
   void **plugin_mem_p = va_arg (*args, void **);
   srv6_end_gtp4_param_t *ls_mem;
-  u32 local_prefixlen;
+  u32 v4src_position;
 
   if (!unformat (input, "end.m.gtp4.e v4src_position %d",
-	  &local_prefixlen))
+	  &v4src_position))
     return 0;
 
   ls_mem = clib_mem_alloc_aligned_at_offset (sizeof *ls_mem, 0, 0, 1);
   clib_memset (ls_mem, 0, sizeof *ls_mem);
   *plugin_mem_p = ls_mem;
 
-  ls_mem->local_prefixlen = local_prefixlen;
+  ls_mem->v4src_position = v4src_position;
 
   return 1;
 }

--- a/src/plugins/srv6-mobile/mobile.h
+++ b/src/plugins/srv6-mobile/mobile.h
@@ -36,12 +36,17 @@ typedef struct srv6_end_gtp6_param_s
 
 typedef struct srv6_end_gtp4_param_s
 {
-  u32 local_prefixlen;
+  ip6_address_t sr_prefix;
+  u32 sr_prefixlen;
+
+  ip6_address_t v6src_prefix;
+  u32 v6src_prefixlen;
+
+  u32 v4src_position;
 } srv6_end_gtp4_param_t;
 
 typedef struct srv6_end_main_v4_s
 {
-
   vlib_main_t *vlib_main;
   vnet_main_t *vnet_main;
 
@@ -55,7 +60,19 @@ typedef struct srv6_end_main_v4_s
 
 } srv6_end_main_v4_t;
 
+typedef struct srv6_end_main_v4_decap_s
+{
+  vlib_main_t *vlib_main;
+  vnet_main_t *vnet_main;
+
+  u32 end_m_gtp4_d_node_index;
+  u32 error_node_index;
+
+  ip6_header_t cache_hdr;
+} srv6_end_main_v4_decap_t;
+
 extern srv6_end_main_v4_t srv6_end_main_v4;
+extern srv6_end_main_v4_decap_t srv6_end_main_v4_decap;
 extern vlib_node_registration_t srv6_end_m_gtp4_e;
 
 typedef struct srv6_end_main_v6_s

--- a/src/plugins/srv6-mobile/node.c
+++ b/src/plugins/srv6-mobile/node.c
@@ -54,6 +54,10 @@ format_srv6_end_rewrite_trace6 (u8 * s, va_list * args)
   _(M_GTP4_E_PACKETS, "srv6 End.M.GTP4.E packets") \
   _(M_GTP4_E_BAD_PACKETS, "srv6 End.M.GTP4.E bad packets")
 
+#define foreach_srv6_end_v4_d_error \
+  _(M_GTP4_D_PACKETS, "srv6 End.M.GTP4.D packets") \
+  _(M_GTP4_D_BAD_PACKETS, "srv6 End.M.GTP4.D bad packets")
+
 #define foreach_srv6_end_v6_e_error \
   _(M_GTP6_E_PACKETS, "srv6 End.M.GTP6.E packets") \
   _(M_GTP6_E_BAD_PACKETS, "srv6 End.M.GTP6.E bad packets")
@@ -73,6 +77,14 @@ typedef enum
 #undef _
     SRV6_END_N_V4_ERROR,
 } srv6_end_error_v4_t;
+
+typedef enum
+{
+#define _(sym,str) SRV6_END_ERROR_##sym,
+  foreach_srv6_end_v4_d_error
+#undef _
+    SRV6_END_N_V4_D_ERROR,
+} srv6_end_error_v4_d_t;
 
 typedef enum
 {
@@ -104,6 +116,12 @@ static char *srv6_end_error_v4_strings[] = {
 #undef _
 };
 
+static char *srv6_end_error_v4_d_strings[] = {
+#define _(sym,string) string,
+  foreach_srv6_end_v4_d_error
+#undef _
+};
+
 static char *srv6_end_error_v6_e_strings[] = {
 #define _(sym,string) string,
   foreach_srv6_end_v6_e_error
@@ -128,6 +146,13 @@ typedef enum
   SRV6_END_M_GTP4_E_NEXT_LOOKUP,
   SRV6_END_M_GTP4_E_N_NEXT,
 } srv6_end_m_gtp4_e_next_t;
+
+typedef enum
+{
+  SRV6_END_M_GTP4_D_NEXT_DROP,
+  SRV6_END_M_GTP4_D_NEXT_LOOKUP,
+  SRV6_END_M_GTP4_D_N_NEXT,
+} srv6_end_m_gtp4_d_next_t;
 
 typedef enum
 {
@@ -296,8 +321,8 @@ VLIB_NODE_FN (srv6_end_m_gtp4_e) (vlib_main_t * vm,
               hdr0->gtpu.teid = teid;
               hdr0->gtpu.length = clib_host_to_net_u16 (len0);
 
-	      offset = ls_param->local_prefixlen / 8;
-	      shift = ls_param->local_prefixlen % 8;
+	      offset = ls_param->v4src_position / 8;
+	      shift = ls_param->v4src_position % 8;
 
 	      if (PREDICT_TRUE(shift == 0)) {
 		for (index = 0; index < 4; index ++) {
@@ -361,6 +386,245 @@ VLIB_NODE_FN (srv6_end_m_gtp4_e) (vlib_main_t * vm,
   return frame->n_vectors;
 }
 
+// Function for SRv6 GTP4.D function.
+VLIB_NODE_FN (srv6_end_m_gtp4_d) (vlib_main_t * vm,
+                                  vlib_node_runtime_t * node,
+                                  vlib_frame_t * frame)
+{
+  srv6_end_main_v4_decap_t *sm = &srv6_end_main_v4_decap;
+  ip6_sr_main_t *sm2 = &sr_main;
+  u32 n_left_from, next_index, *from, *to_next;
+  u32 thread_index = vm->thread_index;
+
+  u32 good_n = 0, bad_n = 0;
+
+  from = vlib_frame_vector_args (frame);
+  n_left_from = frame->n_vectors;
+  next_index = node->cached_next_index;
+
+  while (n_left_from > 0)
+    {
+      u32 n_left_to_next;
+
+      vlib_get_next_frame (vm, node, next_index, to_next, n_left_to_next);
+
+      while (n_left_from > 0 && n_left_to_next > 0)
+	{
+          u32 bi0;
+	  vlib_buffer_t *b0;
+	  ip6_sr_localsid_t *ls0;
+	  srv6_end_gtp4_param_t *ls_param;
+	  ip4_header_t *ip4;
+
+          uword len0;
+          
+	  u32 next0 = SRV6_END_M_GTP4_D_NEXT_LOOKUP;
+
+          // defaults
+          bi0 = from[0];
+          to_next[0] = bi0;
+          from += 1;
+          to_next += 1;
+          n_left_from -= 1;
+          n_left_to_next -= 1;
+
+          b0 = vlib_get_buffer (vm, bi0);
+
+	  ls0 =
+            pool_elt_at_index (sm2->localsids,
+                               vnet_buffer (b0)->ip.adj_index[VLIB_TX]);
+
+	  ls_param = (srv6_end_gtp4_param_t *)ls0->plugin_mem;
+
+          len0 = vlib_buffer_length_in_chain (vm, b0);
+
+	  ip4 = vlib_buffer_get_current (b0);
+
+	  if (ip4->protocol != IP_PROTOCOL_UDP
+	   || len0 < sizeof(ip4_gtpu_header_t))
+            {
+              next0 = SRV6_END_M_GTP4_D_NEXT_DROP;
+
+              bad_n++;
+            }
+          else
+            {
+	      uword *p;
+	      ip6_sr_policy_t *sr_policy = NULL;
+	      ip6_sr_sl_t *sl = NULL;
+	      u32 *sl_index;
+	      u32 hdr_len;
+
+	      ip4_gtpu_header_t *hdr;
+	      ip4_address_t src, dst;
+	      u8 *srcp, *dstp;
+	      ip6_header_t *encap;
+	      ip6_address_t seg;
+	      ip6_address_t src6;
+	      u32 teid;
+	      u8 *teidp;
+	      u32 offset, shift, index;
+	      ip6srv_combo_header_t *ip6srv;
+
+	      hdr = (ip4_gtpu_header_t *)ip4;
+
+	      teid = hdr->gtpu.teid;
+	      teidp = (u8 *) &teid;
+
+	      src = hdr->ip4.src_address;
+	      srcp = (u8 *) &src;
+
+	      dst = hdr->ip4.dst_address;
+	      dstp = (u8 *) &dst;
+
+	      seg = ls_param->sr_prefix;
+
+	      offset = ls_param->sr_prefixlen / 8;
+	      shift = ls_param->sr_prefixlen % 8;
+
+	      if (PREDICT_TRUE(shift == 0))
+		{
+		  clib_memcpy_fast (&seg.as_u8[offset], dstp, 4);
+
+		  clib_memcpy_fast (&seg.as_u8[offset + 5], teidp, 4);
+		}
+	      else
+		{
+		  for (index = 0; index < 4; index++)
+		    {
+		      seg.as_u8[offset + index] |= dstp[index] >> shift;
+		      seg.as_u8[offset + index + 1] |= dstp[index] << (8 - shift);
+
+		      seg.as_u8[offset + index + 5] |= teidp[index] >> shift;
+		      seg.as_u8[offset + index + 6] |= teidp[index] << (8 - shift);
+		    }
+		}
+
+	      src6 = ls_param->v6src_prefix;
+
+	      offset = ls_param->v6src_prefixlen / 8;
+	      shift = ls_param->v6src_prefixlen % 8;
+
+	      if (PREDICT_TRUE(shift == 0))
+		{
+		  clib_memcpy_fast (&src6.as_u8[offset], srcp, 4);
+		}
+	      else
+		{
+		  for (index = 0; index < 4; index++)
+		    {
+		      src6.as_u8[offset + index] |= srcp[offset] >> shift;
+		      src6.as_u8[offset + index + 1] |= srcp[offset] << (8 - shift);
+		    }
+		}
+
+	      vlib_buffer_advance (b0, (word) sizeof(ip4_gtpu_header_t));
+	      encap = vlib_buffer_get_current (b0);
+	      len0 = vlib_buffer_length_in_chain (vm, b0);
+
+              p = mhash_get (&sm2->sr_policies_index_hash, &ls_param->sr_prefix);
+              if (p)
+                {
+                  sr_policy = pool_elt_at_index (sm2->sr_policies, p[0]);
+                }
+
+              if (sr_policy)
+                {
+                  vec_foreach (sl_index, sr_policy->segments_lists)
+                    {
+                      sl = pool_elt_at_index (sm2->sid_lists, *sl_index);
+                      if (sl != NULL)
+                        break;
+                    }
+                }
+
+              if (sl)
+                {
+                  hdr_len = sizeof (ip6srv_combo_header_t);
+                  hdr_len += vec_len (sl->segments) * sizeof(ip6_address_t);
+                  hdr_len += sizeof (ip6_address_t);
+                }
+	      else
+	        {
+		  hdr_len = sizeof(ip6_header_t);
+		}
+
+	      vlib_buffer_advance (b0, - (word) hdr_len);
+	      ip6srv = vlib_buffer_get_current (b0);
+
+	      if (sl)
+		{
+		  clib_memcpy_fast (ip6srv, sl->rewrite, vec_len(sl->rewrite));
+
+		  ip6srv->ip.protocol = IP_PROTOCOL_IPV6_ROUTE;
+
+		  ip6srv->sr.segments_left += 1;
+		  ip6srv->sr.first_segment += 1;
+
+		  ip6srv->sr.length += sizeof(ip6_address_t) / 8;
+		  ip6srv->sr.segments[0] = seg;
+
+		  if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) == 0x60)
+		    ip6srv->sr.protocol = IP_PROTOCOL_IPV6;
+		  else
+		    ip6srv->sr.protocol = IP_PROTOCOL_IP_IN_IP;
+
+		  clib_memcpy_fast (&ip6srv->sr.segments[1],
+				  (u8 *)(sl->rewrite + sizeof(ip6_header_t) + sizeof(ip6_sr_header_t)),
+				  vec_len(sl->segments) * sizeof(ip6_address_t));
+		}
+	      else
+		{
+		  clib_memcpy_fast (ip6srv, &sm->cache_hdr, sizeof(ip6_header_t));
+
+		  ip6srv->ip.dst_address = seg;
+
+		  if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) == 0x60)
+		    ip6srv->ip.protocol = IP_PROTOCOL_IP_IN_IP;
+		}
+
+ 	      ip6srv->ip.src_address = src6;
+
+	      ip6srv->ip.payload_length = clib_host_to_net_u16 (len0 + hdr_len - sizeof(ip6_header_t));
+
+              good_n++;
+
+  	      if (PREDICT_FALSE (node->flags & VLIB_NODE_FLAG_TRACE) &&
+	          PREDICT_FALSE (b0->flags & VLIB_BUFFER_IS_TRACED))
+	        {
+                  srv6_end_rewrite_trace_t *tr =
+		    vlib_add_trace (vm, node, b0, sizeof (*tr));
+	          clib_memcpy (tr->src.as_u8, ip6srv->ip.src_address.as_u8,
+			       sizeof (tr->src.as_u8));
+	          clib_memcpy (tr->dst.as_u8, ip6srv->ip.dst_address.as_u8,
+			       sizeof (tr->dst.as_u8));
+	        }
+	    }
+
+          vlib_increment_combined_counter
+            (((next0 ==
+               SRV6_END_M_GTP4_D_NEXT_DROP) ? &(sm2->sr_ls_invalid_counters) :
+              &(sm2->sr_ls_valid_counters)), thread_index, ls0 - sm2->localsids,
+             1, vlib_buffer_length_in_chain (vm, b0));
+
+          vlib_validate_buffer_enqueue_x1 (vm, node, next_index, to_next,
+					   n_left_to_next, bi0, next0);
+        }
+
+      vlib_put_next_frame (vm, node, next_index, n_left_to_next);
+    }
+
+  vlib_node_increment_counter (vm, sm->end_m_gtp4_d_node_index,
+                               SRV6_END_ERROR_M_GTP4_D_BAD_PACKETS,
+			       bad_n);
+
+  vlib_node_increment_counter (vm, sm->end_m_gtp4_d_node_index,
+                               SRV6_END_ERROR_M_GTP4_D_PACKETS,
+			       good_n);
+
+  return frame->n_vectors;
+}
+
 VLIB_REGISTER_NODE (srv6_end_m_gtp4_e) = {
   .name = "srv6-end-m-gtp4-e",
   .vector_size = sizeof (u32),
@@ -374,6 +638,22 @@ VLIB_REGISTER_NODE (srv6_end_m_gtp4_e) = {
   .next_nodes = {
     [SRV6_END_M_GTP4_E_NEXT_DROP] = "error-drop",
     [SRV6_END_M_GTP4_E_NEXT_LOOKUP] = "ip4-lookup",
+  },
+};
+
+VLIB_REGISTER_NODE (srv6_end_m_gtp4_d) = {
+  .name = "srv6-end-m-gtp4-d",
+  .vector_size = sizeof (u32),
+  .format_trace = format_srv6_end_rewrite_trace,
+  .type = VLIB_NODE_TYPE_INTERNAL,
+
+  .n_errors = ARRAY_LEN (srv6_end_error_v4_d_strings),
+  .error_strings = srv6_end_error_v4_d_strings,
+
+  .n_next_nodes = SRV6_END_M_GTP4_D_N_NEXT,
+  .next_nodes = {
+    [SRV6_END_M_GTP4_D_NEXT_DROP] = "error-drop",
+    [SRV6_END_M_GTP4_D_NEXT_LOOKUP] = "ip6-lookup",
   },
 };
 
@@ -622,28 +902,22 @@ VLIB_NODE_FN (srv6_end_m_gtp6_d) (vlib_main_t * vm,
 	      teid = hdr0->gtpu.teid;
 	      teidp = (u8 *) &teid;
 	      
-	      if (ls_param->sr_prefixlen != 0)
-		{
-	          offset = ls_param->sr_prefixlen / 8;
-	          shift = ls_param->sr_prefixlen % 8;
+	      offset = ls_param->sr_prefixlen / 8;
+	      shift = ls_param->sr_prefixlen % 8;
 
-		  offset += 1;
-		  if (PREDICT_TRUE (shift == 0))
+	      offset += 1;
+	      if (PREDICT_TRUE (shift == 0))
+	        {
+		  clib_memcpy_fast (&seg0.as_u8[offset], teidp, 4);
+	        }
+	      else
+	        {
+                  int idx;
+
+	          for (idx = 0; idx < 4; idx++)
 	            {
-	              seg0.as_u8[offset] = teidp[0];
-		      seg0.as_u8[offset+1] = teidp[1];
-		      seg0.as_u8[offset+2] = teidp[2];
-		      seg0.as_u8[offset+3] = teidp[3];
-		    }
-		  else
-		    {
-                      int idx;
-
-		      for (idx = 0; idx < 4; idx++)
-		        {
- 			  seg0.as_u8[offset + idx] |= teidp[idx] >> shift;
-			  seg0.as_u8[offset + idx + 1] |= teidp[idx] << shift;
-			}
+ 	  	      seg0.as_u8[offset + idx] |= teidp[idx] >> shift;
+		      seg0.as_u8[offset + idx + 1] |= teidp[idx] << (8 - shift);
 		    }
 		}
 
@@ -844,28 +1118,22 @@ VLIB_NODE_FN (srv6_end_m_gtp6_d_di) (vlib_main_t * vm,
 	      teid = hdr0->gtpu.teid;
 	      teidp = (u8 *) &teid;
 	      
-	      if (ls_param->sr_prefixlen != 0)
-		{
-	          offset = ls_param->sr_prefixlen / 8;
-	          shift = ls_param->sr_prefixlen % 8;
+	      offset = ls_param->sr_prefixlen / 8;
+	      shift = ls_param->sr_prefixlen % 8;
 
-		  offset += 1;
-		  if (PREDICT_TRUE (shift == 0))
+	      offset += 1;
+	      if (PREDICT_TRUE (shift == 0))
+	        {
+		  clib_memcpy_fast (&seg0.as_u8[offset], teidp, 4);
+		}
+  	      else
+	        {
+                  int idx;
+
+	          for (idx = 0; idx < 4; idx++)
 	            {
-	              seg0.as_u8[offset] = teidp[0];
-		      seg0.as_u8[offset+1] = teidp[1];
-		      seg0.as_u8[offset+2] = teidp[2];
-		      seg0.as_u8[offset+3] = teidp[3];
-		    }
-		  else
-		    {
-                      int idx;
-
-		      for (idx = 0; idx < 4; idx++)
-		        {
- 			  seg0.as_u8[offset + idx] |= teidp[idx] >> shift;
-			  seg0.as_u8[offset + idx + 1] |= teidp[idx] << shift;
-			}
+ 	  	      seg0.as_u8[offset + idx] |= teidp[idx] >> shift;
+		      seg0.as_u8[offset + idx + 1] |= teidp[idx] << (8 - shift);
 		    }
 		}
 


### PR DESCRIPTION
Now GTP4.D is becoming one of plug-in as a part of srv6-mobile. In order to enable GTP4.D, the following command can be used.

sr localsid prefix <v4 mapped v6 address>/<prefixlen> behavior end.m.gtp4.d <SR-Prefix> v6srv_prefix <v6src-prefix>

However, unformat_ip6_address does not support the notation of v4 mapped v6 address now. So, the standard notation for IPv6 address must be used. For example, if specifying 172.20.0.1/32, ::ffff:ac14:1/128 must be used for now.