### PR TITLE
Fix #14

### DIFF
--- a/extras/ietf105/runner.py
+++ b/extras/ietf105/runner.py
@@ -666,7 +666,6 @@ class Program(object):
 
         c4.vppctl_exec("sr localsid prefix D4::/32 behavior end.m.gtp4.e v4src_position 64")
 
-        #c1.set_ipv6_route("eth1", "A1::2", "D2::/128")
         c2.set_ipv6_route("eth2", "A2::2", "D3::/128")
         c2.set_ipv6_route("eth1", "A1::1", "C::/120")
         c3.set_ipv6_route("eth2", "A3::2", "D4::/32")

--- a/extras/ietf105/runner.py
+++ b/extras/ietf105/runner.py
@@ -658,7 +658,7 @@ class Program(object):
 
         c1.vppctl_exec("set sr encaps source addr A1::1")
         c1.vppctl_exec("sr policy add bsid D4:: next D2:: next D3::")
-        c1.vppctl_exec("sr localsid prefix ::ffff:ac14:0001/128 behavior end.m.gtp4.d D4::/32 v6src_prefix C1::/64")
+        c1.vppctl_exec("sr localsid prefix ::ffff:ac14:0001/128 behavior end.m.gtp4.d D4::/32 v6src_prefix C1::/64 nhtype ipv4")
 
         c2.vppctl_exec("sr localsid address D2:: behavior end")
 

--- a/src/plugins/srv6-mobile/gtp4_d.c
+++ b/src/plugins/srv6-mobile/gtp4_d.c
@@ -71,7 +71,21 @@ clb_format_srv6_end_m_gtp4_d (u8 * s, va_list * args)
 
   s = format (s, "SR Prefix: %U/%d, ", format_ip6_address, &ls_mem->sr_prefix, ls_mem->sr_prefixlen);
 
-  s = format (s, "v6src Prefix: %U/%d\n", format_ip6_address, &ls_mem->v6src_prefix, ls_mem->v6src_prefixlen);
+  s = format (s, "v6src Prefix: %U/%d", format_ip6_address, &ls_mem->v6src_prefix, ls_mem->v6src_prefixlen);
+
+  if (ls_mem->nhtype != SRV6_NHTYPE_NONE)
+    {
+      if (ls_mem->nhtype == SRV6_NHTYPE_IPV4)
+        s = format (s, ", NHType IPv4\n");
+      else if (ls_mem->nhtype == SRV6_NHTYPE_IPV6)
+        s = format (s, ", NHType IPv6\n");
+      else if (ls_mem->nhtype == SRV6_NHTYPE_NON_IP)
+        s = format (s, ", NHType Non-IP\n");
+      else
+        s = format (s, ", NHType Unknow(%d)\n", ls_mem->nhtype);
+    }
+  else
+    s = format(s, "\n");
 
   return s;
 }
@@ -85,10 +99,33 @@ clb_unformat_srv6_end_m_gtp4_d (unformat_input_t * input, va_list * args)
   u32 sr_prefixlen;
   ip6_address_t v6src_prefix;
   u32 v6src_prefixlen;
+  u8 nhtype;
 
-  if (!unformat (input, "end.m.gtp4.d %U/%d v6src_prefix %U/%d",
+  if (unformat (input, "end.m.gtp4.d %U/%d v6src_prefix %U/%d",
 	 unformat_ip6_address, &sr_prefix, &sr_prefixlen,
 	 unformat_ip6_address, &v6src_prefix, &v6src_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_NONE;
+    }
+  else if (unformat (input, "end.m.gtp4.d %U/%d v6src_prefix %U/%d nhtype ipv4",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen,
+	 unformat_ip6_address, &v6src_prefix, &v6src_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_IPV4;
+    }
+  else if (unformat (input, "end.m.gtp4.d %U/%d v6src_prefix %U/%d nhtype ipv6",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen,
+	 unformat_ip6_address, &v6src_prefix, &v6src_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_IPV6;
+    }
+  else if (unformat (input, "end.m.gtp4.d %U/%d v6src_prefix %U/%d nhtype non-ip",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen,
+	 unformat_ip6_address, &v6src_prefix, &v6src_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_NON_IP;
+    }
+  else
     {
       return 0;
     }
@@ -102,6 +139,8 @@ clb_unformat_srv6_end_m_gtp4_d (unformat_input_t * input, va_list * args)
 
   ls_mem->v6src_prefix = v6src_prefix;
   ls_mem->v6src_prefixlen = v6src_prefixlen;
+
+  ls_mem->nhtype = nhtype;
 
   return 1;
 }

--- a/src/plugins/srv6-mobile/gtp4_d.c
+++ b/src/plugins/srv6-mobile/gtp4_d.c
@@ -60,7 +60,7 @@ const static char *const *const dpo_nodes[DPO_PROTO_NUM] = {
 static u8 fn_name[] = "SRv6-End.M.GTP4.D-plugin";
 static u8 keyword_str[] = "end.m.gtp4.d";
 static u8 def_str[] = "Endpoint function with dencapsulation for IPv6/GTP tunnel";
-static u8 param_str[] = "<sr-prefix>/<sr-prefixlen> v6src_prefix <v6src_prefix>/<prefixlen>";
+static u8 param_str[] = "<sr-prefix>/<sr-prefixlen> v6src_prefix <v6src_prefix>/<prefixlen> [nhtype <nhtype>]";
 
 static u8 *
 clb_format_srv6_end_m_gtp4_d (u8 * s, va_list * args)
@@ -101,13 +101,7 @@ clb_unformat_srv6_end_m_gtp4_d (unformat_input_t * input, va_list * args)
   u32 v6src_prefixlen;
   u8 nhtype;
 
-  if (unformat (input, "end.m.gtp4.d %U/%d v6src_prefix %U/%d",
-	 unformat_ip6_address, &sr_prefix, &sr_prefixlen,
-	 unformat_ip6_address, &v6src_prefix, &v6src_prefixlen))
-    {
-      nhtype = SRV6_NHTYPE_NONE;
-    }
-  else if (unformat (input, "end.m.gtp4.d %U/%d v6src_prefix %U/%d nhtype ipv4",
+  if (unformat (input, "end.m.gtp4.d %U/%d v6src_prefix %U/%d nhtype ipv4",
 	 unformat_ip6_address, &sr_prefix, &sr_prefixlen,
 	 unformat_ip6_address, &v6src_prefix, &v6src_prefixlen))
     {
@@ -124,6 +118,12 @@ clb_unformat_srv6_end_m_gtp4_d (unformat_input_t * input, va_list * args)
 	 unformat_ip6_address, &v6src_prefix, &v6src_prefixlen))
     {
       nhtype = SRV6_NHTYPE_NON_IP;
+    }
+  else if (unformat (input, "end.m.gtp4.d %U/%d v6src_prefix %U/%d",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen,
+	 unformat_ip6_address, &v6src_prefix, &v6src_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_NONE;
     }
   else
     {

--- a/src/plugins/srv6-mobile/gtp6_d.c
+++ b/src/plugins/srv6-mobile/gtp6_d.c
@@ -103,17 +103,17 @@ clb_unformat_srv6_end_m_gtp6_d (unformat_input_t * input, va_list * args)
       nhtype = SRV6_NHTYPE_NONE;
     }
   else if (unformat (input, "end.m.gtp6.d %U/%d nh-type ipv4",
-	 unformat_ip6_address, &sr_prefix, &sr_prefixklen))
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
     {
       nhtype = SRV6_NHTYPE_IPV4;
     }
   else if (unformat (input, "end.m.gtp6.d %U/%d nh-type ipv6",
-	 unformat_ip6_address, &sr_prefix, &sr_prefixklen))
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
     {
       nhtype = SRV6_NHTYPE_IPV6;
     }
   else if (unformat (input, "end.m.gtp6.d %U/%d nh-type none",
-	 unformat_ip6_address, &sr_prefix, &sr_prefixklen))
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
     {
       nhtype = SRV6_NHTYPE_NON_IP;
     }

--- a/src/plugins/srv6-mobile/gtp6_d.c
+++ b/src/plugins/srv6-mobile/gtp6_d.c
@@ -69,7 +69,21 @@ clb_format_srv6_end_m_gtp6_d (u8 * s, va_list * args)
 
   s = format (s, "SRv6 End gtp6.d\n\t");
 
-  s = format (s, "SR Prefix: %U/%d\n", format_ip6_address, &ls_mem->sr_prefix, ls_mem->sr_prefixlen);
+  s = format (s, "SR Prefix: %U/%d", format_ip6_address, &ls_mem->sr_prefix, ls_mem->sr_prefixlen);
+
+  if (ls_mem->nhtype != SRV6_NHTYPE_NONE)
+    {
+      if (ls_mem->nhtype == SRV6_NHTYPE_IPV4)
+	s = format (s, ", NHType IPv4\n");
+      else if (ls_mem->nhtype == SRV6_NHTYPE_IPV6)
+	s = format (s, ", NHType IPv6\n");
+      else if (ls_mem->nhtype == SRV6_NHTYPE_NON_IP)
+	s = format (s, ", NHType Non-IP\n");
+      else
+	s = format (s, ", NHType Unknow(%d)\n", ls_mem->nhtype);
+    } 
+  else
+    s = format(s, "\n");
 
   return s;
 }
@@ -81,9 +95,29 @@ clb_unformat_srv6_end_m_gtp6_d (unformat_input_t * input, va_list * args)
   srv6_end_gtp6_param_t *ls_mem;
   ip6_address_t sr_prefix;
   u32 sr_prefixlen;
+  u8 nhtype;
 
-  if (!unformat (input, "end.m.gtp6.d %U/%d",
+  if (unformat (input, "end.m.gtp6.d %U/%d",
 	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_NONE;
+    }
+  else if (unformat (input, "end.m.gtp6.d %U/%d nh-type ipv4",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixklen))
+    {
+      nhtype = SRV6_NHTYPE_IPV4;
+    }
+  else if (unformat (input, "end.m.gtp6.d %U/%d nh-type ipv6",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixklen))
+    {
+      nhtype = SRV6_NHTYPE_IPV6;
+    }
+  else if (unformat (input, "end.m.gtp6.d %U/%d nh-type none",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixklen))
+    {
+      nhtype = SRV6_NHTYPE_NON_IP;
+    }
+  else
     {
       return 0;
     }
@@ -94,6 +128,8 @@ clb_unformat_srv6_end_m_gtp6_d (unformat_input_t * input, va_list * args)
 
   ls_mem->sr_prefix = sr_prefix;
   ls_mem->sr_prefixlen = sr_prefixlen;
+
+  ls_mem->nhtype = nhtype;
 
   return 1;
 }

--- a/src/plugins/srv6-mobile/gtp6_d.c
+++ b/src/plugins/srv6-mobile/gtp6_d.c
@@ -60,7 +60,7 @@ const static char *const *const dpo_nodes[DPO_PROTO_NUM] = {
 static u8 fn_name[] = "SRv6-End.M.GTP6.D-plugin";
 static u8 keyword_str[] = "end.m.gtp6.d";
 static u8 def_str[] = "Endpoint function with dencapsulation for IPv6/GTP tunnel";
-static u8 param_str[] = "<sr-prefix>/<sr-prefixlen>";
+static u8 param_str[] = "<sr-prefix>/<sr-prefixlen> [nhtype <nhtype>]";
 
 static u8 *
 clb_format_srv6_end_m_gtp6_d (u8 * s, va_list * args)
@@ -97,12 +97,7 @@ clb_unformat_srv6_end_m_gtp6_d (unformat_input_t * input, va_list * args)
   u32 sr_prefixlen;
   u8 nhtype;
 
-  if (unformat (input, "end.m.gtp6.d %U/%d",
-	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
-    {
-      nhtype = SRV6_NHTYPE_NONE;
-    }
-  else if (unformat (input, "end.m.gtp6.d %U/%d nh-type ipv4",
+  if (unformat (input, "end.m.gtp6.d %U/%d nh-type ipv4",
 	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
     {
       nhtype = SRV6_NHTYPE_IPV4;
@@ -116,6 +111,11 @@ clb_unformat_srv6_end_m_gtp6_d (unformat_input_t * input, va_list * args)
 	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
     {
       nhtype = SRV6_NHTYPE_NON_IP;
+    }
+  else if (unformat (input, "end.m.gtp6.d %U/%d",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_NONE;
     }
   else
     {

--- a/src/plugins/srv6-mobile/gtp6_d_di.c
+++ b/src/plugins/srv6-mobile/gtp6_d_di.c
@@ -60,7 +60,7 @@ const static char *const *const dpo_nodes[DPO_PROTO_NUM] = {
 static u8 fn_name[] = "SRv6-End.M.GTP6.D.DI-plugin";
 static u8 keyword_str[] = "end.m.gtp6.d.di";
 static u8 def_str[] = "Endpoint function with drop-in dencapsulation for IPv6/GTP tunnel";
-static u8 param_str[] = "<sr-prefix>/<sr-prefixlen>";
+static u8 param_str[] = "<sr-prefix>/<sr-prefixlen> [nhtype <nhtype>]";
 
 static u8 *
 clb_format_srv6_end_m_gtp6_d_di (u8 * s, va_list * args)
@@ -97,12 +97,7 @@ clb_unformat_srv6_end_m_gtp6_d_di (unformat_input_t * input, va_list * args)
   u32 sr_prefixlen = 0;
   u8 nhtype;
 
-  if (unformat (input, "end.m.gtp6.d.di %U/%d",
-	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
-    {
-      nhtype = SRV6_NHTYPE_NONE;
-    }
-  else if (unformat (input, "end.m.gtp6.d.di %U/%d nhtype ipv4",
+  if (unformat (input, "end.m.gtp6.d.di %U/%d nhtype ipv4",
 	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
     {
       nhtype = SRV6_NHTYPE_IPV4;
@@ -116,6 +111,11 @@ clb_unformat_srv6_end_m_gtp6_d_di (unformat_input_t * input, va_list * args)
 	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
     {
       nhtype = SRV6_NHTYPE_NON_IP;
+    }
+  else if (unformat (input, "end.m.gtp6.d.di %U/%d",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_NONE;
     }
   else
     {

--- a/src/plugins/srv6-mobile/gtp6_d_di.c
+++ b/src/plugins/srv6-mobile/gtp6_d_di.c
@@ -69,7 +69,21 @@ clb_format_srv6_end_m_gtp6_d_di (u8 * s, va_list * args)
 
   s = format (s, "SRv6 End gtp6.d Drop-in\n\t");
 
-  s = format (s, "SR Prefix: %U/%d\n", format_ip6_address, &ls_mem->sr_prefix, ls_mem->sr_prefixlen);
+  s = format (s, "SR Prefix: %U/%d", format_ip6_address, &ls_mem->sr_prefix, ls_mem->sr_prefixlen);
+
+  if (ls_mem->nhtype != SRV6_NHTYPE_NONE)
+    {
+      if (ls_mem->nhtype == SRV6_NHTYPE_IPV4)
+        s = format (s, ", NHType IPv4\n");
+      else if (ls_mem->nhtype == SRV6_NHTYPE_IPV6)
+        s = format (s, ", NHType IPv6\n");
+      else if (ls_mem->nhtype == SRV6_NHTYPE_NON_IP)
+        s = format (s, ", NHType Non-IP\n");
+      else
+        s = format (s, ", NHType Unknow(%d)\n", ls_mem->nhtype);
+    }
+  else
+    s = format(s, "\n");
 
   return s;
 }
@@ -81,9 +95,29 @@ clb_unformat_srv6_end_m_gtp6_d_di (unformat_input_t * input, va_list * args)
   srv6_end_gtp6_param_t *ls_mem;
   ip6_address_t sr_prefix;
   u32 sr_prefixlen = 0;
+  u8 nhtype;
 
-  if (!unformat (input, "end.m.gtp6.d.di %U/%d",
+  if (unformat (input, "end.m.gtp6.d.di %U/%d",
 	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_NONE;
+    }
+  else if (unformat (input, "end.m.gtp6.d.di %U/%d nhtype ipv4",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_IPV4;
+    }
+  else if (unformat (input, "end.m.gtp6.d.di %U/%d nhtype ipv6",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_IPV6;
+    }
+  else if (unformat (input, "end.m.gtp6.d.di %U/%d nhtype non-ip",
+	 unformat_ip6_address, &sr_prefix, &sr_prefixlen))
+    {
+      nhtype = SRV6_NHTYPE_NON_IP;
+    }
+  else
     {
       return 0;
     }
@@ -94,6 +128,7 @@ clb_unformat_srv6_end_m_gtp6_d_di (unformat_input_t * input, va_list * args)
 
   ls_mem->sr_prefix = sr_prefix;
   ls_mem->sr_prefixlen = sr_prefixlen;
+  ls_mem->nhtype = nhtype;
 
   return 1;
 }

--- a/src/plugins/srv6-mobile/mobile.h
+++ b/src/plugins/srv6-mobile/mobile.h
@@ -28,14 +28,27 @@
 
 #define SRV6_GTP_UDP_DST_PORT 2152
 
+#define SRV6_NHTYPE_NONE 	0
+#define SRV6_NHTYPE_IPV4 	1
+#define SRV6_NHTYPE_IPV6 	2
+#define SRV6_NHTYPE_NON_IP	3
+
+#ifndef IP_PROTOCOL_NONE
+#define IP_PROTOCOL_NONE	59
+#endif
+
 typedef struct srv6_end_gtp6_param_s
 {
+  u8 nhtype;
+
   ip6_address_t sr_prefix;
   u32 sr_prefixlen;
 } srv6_end_gtp6_param_t;
 
 typedef struct srv6_end_gtp4_param_s
 {
+  u8 nhtype;
+
   ip6_address_t sr_prefix;
   u32 sr_prefixlen;
 

--- a/src/plugins/srv6-mobile/node.c
+++ b/src/plugins/srv6-mobile/node.c
@@ -564,10 +564,33 @@ VLIB_NODE_FN (srv6_end_m_gtp4_d) (vlib_main_t * vm,
 		  ip6srv->sr.length += sizeof(ip6_address_t) / 8;
 		  ip6srv->sr.segments[0] = seg;
 
-		  if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) == 0x60)
-		    ip6srv->sr.protocol = IP_PROTOCOL_IPV6;
-		  else
-		    ip6srv->sr.protocol = IP_PROTOCOL_IP_IN_IP;
+		  if (ls_param->nhtype == SRV6_NHTYPE_NONE)
+	 	    {
+		      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) == 0x60)
+		        ip6srv->sr.protocol = IP_PROTOCOL_IPV6;
+		      else
+		        ip6srv->sr.protocol = IP_PROTOCOL_IP_IN_IP;
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_IPV4)
+		    {
+		      ip6srv->sr.protocol = IP_PROTOCOL_IP_IN_IP;
+		      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x40)
+			{
+			  // Bad encap packet.
+			}
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_IPV6)
+		    {
+		      ip6srv->sr.protocol = IP_PROTOCOL_IPV6;
+		      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x60)
+			{
+			  // Bad encap packet.
+			}
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_NON_IP)
+		    {
+		      ip6srv->sr.protocol = IP_PROTOCOL_NONE;
+		    }
 
 		  clib_memcpy_fast (&ip6srv->sr.segments[1],
 				  (u8 *)(sl->rewrite + sizeof(ip6_header_t) + sizeof(ip6_sr_header_t)),
@@ -579,8 +602,33 @@ VLIB_NODE_FN (srv6_end_m_gtp4_d) (vlib_main_t * vm,
 
 		  ip6srv->ip.dst_address = seg;
 
-		  if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) == 0x60)
-		    ip6srv->ip.protocol = IP_PROTOCOL_IP_IN_IP;
+		  if (ls_param->nhtype == SRV6_NHTYPE_NONE)
+	 	    {
+		      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) == 0x60)
+		        ip6srv->ip.protocol = IP_PROTOCOL_IPV6;
+		      else
+		        ip6srv->ip.protocol = IP_PROTOCOL_IP_IN_IP;
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_IPV4)
+		    {
+		      ip6srv->ip.protocol = IP_PROTOCOL_IP_IN_IP;
+		      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x40)
+			{
+			  // Bad encap packet.
+			}
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_IPV6)
+		    {
+		      ip6srv->ip.protocol = IP_PROTOCOL_IPV6;
+		      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x60)
+			{
+			  // Bad encap packet.
+			}
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_NON_IP)
+		    {
+		      ip6srv->ip.protocol = IP_PROTOCOL_NONE;
+		    }
 		}
 
  	      ip6srv->ip.src_address = src6;
@@ -980,10 +1028,33 @@ VLIB_NODE_FN (srv6_end_m_gtp6_d) (vlib_main_t * vm,
 	          ip6srv->sr.length += sizeof(ip6_address_t) / 8;
 	          ip6srv->sr.segments[0] = seg0;
 
-	          if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) == 0x60)
-		    ip6srv->sr.protocol = IP_PROTOCOL_IPV6;
-		  else
-		    ip6srv->sr.protocol = IP_PROTOCOL_IP_IN_IP;
+		  if (ls_param->nhtype == SRV6_NHTYPE_NONE)
+	 	    {
+	              if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) == 0x60)
+		        ip6srv->sr.protocol = IP_PROTOCOL_IPV6;
+		      else
+		        ip6srv->sr.protocol = IP_PROTOCOL_IP_IN_IP;
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_IPV4)
+	 	    {
+		      ip6srv->sr.protocol = IP_PROTOCOL_IP_IN_IP;
+		      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x40)
+			{
+			  // Bad encap packet.
+			}
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_IPV6)
+	 	    {
+		      ip6srv->sr.protocol = IP_PROTOCOL_IPV6;
+		      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x60)
+			{
+			  // Bad encap packet.
+			}
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_NON_IP)
+	 	    {
+		      ip6srv->sr.protocol = IP_PROTOCOL_NONE;
+		    }
 
 	          clib_memcpy_fast (&ip6srv->sr.segments[1],
 	            (u8 *)(sl->rewrite + sizeof(ip6_header_t) + sizeof(ip6_sr_header_t)),
@@ -996,8 +1067,31 @@ VLIB_NODE_FN (srv6_end_m_gtp6_d) (vlib_main_t * vm,
 		  ip6srv->ip.src_address = dst0;
 		  ip6srv->ip.dst_address = seg0;
 
-	          if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x60)
-	 	    ip6srv->ip.protocol = IP_PROTOCOL_IP_IN_IP;
+		  if (ls_param->nhtype == SRV6_NHTYPE_NONE)
+		    {
+	              if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x60)
+	 	        ip6srv->ip.protocol = IP_PROTOCOL_IP_IN_IP;
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_IPV4)
+		    {
+		      ip6srv->ip.protocol = IP_PROTOCOL_IP_IN_IP;
+		      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x40)
+			{
+			  // Bad encap packet.
+			}
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_IPV6)
+		    {
+		      ip6srv->ip.protocol = IP_PROTOCOL_IPV6;
+		      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x60)
+			{
+			  // Bad encap packet.
+			}
+		    }
+		  else if (ls_param->nhtype == SRV6_NHTYPE_NON_IP)
+		    {
+		      ip6srv->ip.protocol = IP_PROTOCOL_NONE;
+		    }
 		}
 
 	      ip6srv->ip.payload_length = clib_host_to_net_u16 (len0 + hdr_len - sizeof(ip6_header_t));
@@ -1202,15 +1296,34 @@ VLIB_NODE_FN (srv6_end_m_gtp6_d_di) (vlib_main_t * vm,
 	      ip6srv->ip.payload_length = clib_host_to_net_u16 (len0 + hdr_len - sizeof(ip6_header_t));
 	      ip6srv->ip.protocol = IP_PROTOCOL_IPV6_ROUTE;
 
-	      if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) == 0x60)
-		{
-		  ip6srv->sr.protocol = IP_PROTOCOL_IPV6;
-		}
-	      else
+ 	      if (ls_param->nhtype == SRV6_NHTYPE_NONE)
 	        {
-		  ip6srv->sr.protocol = IP_PROTOCOL_IP_IN_IP;
+	          if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) == 0x60)
+	            ip6srv->sr.protocol = IP_PROTOCOL_IPV6;
+	          else
+	            ip6srv->sr.protocol = IP_PROTOCOL_IP_IN_IP;
+	        }
+	      else if (ls_param->nhtype == SRV6_NHTYPE_IPV4)
+	        {
+	          ip6srv->sr.protocol = IP_PROTOCOL_IP_IN_IP;
+	          if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x40)
+	  	    {
+		      // Bad encap packet.
+		    }
 		}
-
+	      else if (ls_param->nhtype == SRV6_NHTYPE_IPV6)
+	        {
+	          ip6srv->sr.protocol = IP_PROTOCOL_IPV6;
+	          if ((encap->ip_version_traffic_class_and_flow_label & 0xF0) != 0x60)
+	  	    {
+		      // Bad encap packet.
+		    }
+	        }
+	      else if (ls_param->nhtype == SRV6_NHTYPE_NON_IP)
+	        {
+	          ip6srv->sr.protocol = IP_PROTOCOL_NONE;
+	        }
+	      
 	      ip6srv->sr.length += ((sizeof(ip6_address_t) * 2) / 8);
 	      ip6srv->sr.segments[0] = dst0;
 	      ip6srv->sr.segments[1] = seg0;


### PR DESCRIPTION
Support the nhtype for gtp4.d, gtp6.d and gtp6.d.di plug-in. The new option is added for sr localsid command like "nhtype [ipv4|ipv6|non-ip]". This option is not mandatory. So, if omitting this option, the payload type is guessed by checking the first nibble.